### PR TITLE
Fix compilation issues with -Wall, add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: build
+
+build:
+	gcc -Wall findmacs.c -o findmacs
+
+clean:
+	rm -f findmacs
+
+.PHONY: build clean


### PR DESCRIPTION
Takes care of the following warnings:
```➜ gcc -Wall findmacs.c -o findmacs
findmacs.c: In function ‘main’:
findmacs.c:233:42: warning: pointer targets in passing argument 3 of ‘getMACs’ differ in signedness [-Wpointer-sign]
   matches = getMACs(fd, interface_index, interface_mac, interface_ip, target, flags, &mac_list_hash);
                                          ^~~~~~~~~~~~~
findmacs.c:69:5: note: expected ‘char *’ but argument is of type ‘unsigned char *’
 int getMACs(int fd, int interface_index, char mac[ETHER_ADDR_LEN], char * ip, char * target, int flags, struct hsearch_data *htab);
     ^~~~~~~
findmacs.c: In function ‘getMACs’:
findmacs.c:258:7: warning: unused variable ‘p’ [-Wunused-variable]
   int p, show = 0, matches = 0;
       ^
findmacs.c:250:18: warning: unused variable ‘target_ip_addr’ [-Wunused-variable]
   struct in_addr target_ip_addr = {0};
                  ^~~~~~~~~~~~~~
findmacs.c: In function ‘split_cidr_range’:
findmacs.c:412:20: warning: suggest parentheses around ‘-’ inside ‘<<’ [-Wparentheses]
   mask = mask << 32-count;
                  ~~^~~~~~
```

Compilation with added Makefile:
```
➜ make clean
rm -f findmacs
➜ make
gcc -Wall findmacs.c -o findmacs
```

Thanks!